### PR TITLE
fix: PDFA WTPDF 1.0 cites "ISO 14289-2" and "ISO 14289" (parts unspecified)

### DIFF
--- a/sources/pdfa-wtpdf-1.0/sections/05-conformance.adoc
+++ b/sources/pdfa-wtpdf-1.0/sections/05-conformance.adoc
@@ -130,7 +130,7 @@ forbidden by this document;
 *[Conformance level for accessibility]* — an embedded file, if necessary to the
 understanding of the containing file, shall be accessible according to
 objectively verifiable standards, e.g., <<W3C-wcag>>. If such an embedded file is
-a PDF file, it shall conform to <<ISO_14289>> and/or to this document's conformance
+a PDF file, it shall conform to <<ISO_14289_all>> and/or to this document's conformance
 level for accessibility.
 
 NOTE: Embedded files referenced from the containing file, for use by a human

--- a/sources/pdfa-wtpdf-1.0/sections/b0-bibliography.adoc
+++ b/sources/pdfa-wtpdf-1.0/sections/b0-bibliography.adoc
@@ -24,3 +24,9 @@ and guidelines
 * [[[ISO_14289-1,ISO 14289-1]]], Document management applications — Electronic
 document file format enhancement for accessibility — Part 1: Use of ISO 32000‑1
 (PDF/UA‑1)
+
+* [[[ISO_14289-2,ISO 14289-2]]], Document management applications — Electronic
+document file format enhancement for accessibility Part 2: Use of ISO 32000-2
+(PDF/UA-2)
+
+* [[[ISO_14289_all,hidden(ISO 14289 (all parts))]]]


### PR DESCRIPTION
Fixes #2

This PR adds ISO 14289-2 as a new bibliographic entry and a hidden "ISO 14289 (all parts)" to satisfy the no-parts-specified reference.

Ping @petervwyatt.