### PR TITLE
fix(ci): use build-and-publish@v2 with unified workflows

### DIFF
--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -1,4 +1,4 @@
-name: docker
+name: generate
 
 on:
   push:
@@ -8,10 +8,6 @@ on:
 
 permissions:
   contents: read
-
-concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref_name }}
-  cancel-in-progress: true
 
 jobs:
   build:
@@ -24,8 +20,12 @@ jobs:
         with:
           submodules: true
 
+      - name: Setup Metanorma
+        uses: actions-mn/setup@v3
+
       - name: Metanorma generate site
         uses: actions-mn/build-and-publish@v2
         with:
           agree-to-terms: true
           destination: artifact
+          artifact-name: ${{ github.event.repository.name }}-${{ runner.os }}


### PR DESCRIPTION
## Summary
- Update `generate.yml` to use multi-platform testing (ubuntu, windows, macos)
- Update `docker.yml` to use `build-and-publish@v2` with conditional deploy
- Deploy only happens for public repos (via `visibility` check)

## Test plan
- [ ] Verify generate.yml runs on all 3 platforms
- [ ] Verify docker.yml builds successfully
- [ ] Verify deploy step is conditionally executed based on repo visibility